### PR TITLE
gentooinstall v0.1-007: stages, threads, refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Automated Gentoo Linux Installation <br>
 <br><br>
 
 ### Features
-- [x] Unattended installation mode with custom-made/imported configurations
-- [x] ...
+- [x] Automatic installation with custom/imported configurations
+- [x] Minimal user interaction (For stages, mirrors only)
+- [ ] ...
 <br><br>
 
 ### Testing / Contributing:
@@ -50,10 +51,9 @@ Automated Gentoo Linux Installation <br>
 • drive: the target drive to format and install on, see "lsblk" and "blkid" for more
 • machineused: set to "hw" for real hardware, "vm" for virtual environments - determines formatting/discarding process
 • part_swap: swap partition size for the linux installation, size x in GB = xG
+• getstage: stage link for TUI browser 
 • zone: the timezone used by the system, keep in mind many DE's need a separate GUI set-up for this too
-• stagelink: link to a stage3 tar, might be replaced with links browser in the future
-• jthreads: number of threads for makeopts, for every package
-• jsplit: split cpu into units of n-cores, determines with njobs, jthreads how many packages are processed at the same time and with how many threads each
+• jsplit: split cpu into units of n-cores, determines with njobs, jthreads how many packages are processed at the same time and with how many threads each (Keep in mind you should have 2GB per thread)
 • use_flg: globaly set use flags (-X to not use/enable, X to use/enable)
 • gprof: the oortage profile that's used, see https://wiki.gentoo.org/wiki/Profile_(Portage) 
 • deflocale, deflocale2: the default locale, currently split into 2 variables 
@@ -61,5 +61,6 @@ Automated Gentoo Linux Installation <br>
 • hostname: the name of the system/host
 • rootpass: root / superuser password 
 • netdev: the network device, e.g: eth0 
+• ... 
 </pre>
 <br>

--- a/config.gentooinstall
+++ b/config.gentooinstall
@@ -5,9 +5,8 @@
 drive="sda"
 machineused="vm"
 part_swap="8G"
+getstage="https://gentoo-mirror.alexxy.name/releases/amd64/autobuilds/"
 zone="Europe/Berlin"
-stagelink="https://gentoo-mirror.alexxy.name//releases/amd64/autobuilds/20220605T170549Z/stage3-amd64-openrc-20220605T170549Z.tar.xz"  # https://www.gentoo.org/downloads/, https://gentoo-mirror.alexxy.name//releases/amd64/autobuilds/
-jthreads="6"  # CPU threads (also, ideally: RAM = threads x 2)
 jsplit="8"  # split cpu into units of n-cores (https://wiki.gentoo.org/wiki/EMERGE_DEFAULT_OPTS)
 use_flg="-systemd -gnome -kde -bluetooth"  # global (-X to not use/enable, X to use/enable)
 gprof="1"
@@ -16,4 +15,4 @@ deflocale2="UTF-8"
 gkernel="0"  # 0 = standard binary, 1 = custom (?)
 hostname="gentoo"
 rootpass="RootPassword0-"
-netdev="enp0s3"  # eth0 
+netdev="enp0s3" 

--- a/discard.sh
+++ b/discard.sh
@@ -2,7 +2,7 @@
 ## Copyright (C) 2022 bunnicash "@bunnicash" and licensed under GPL-2.0
 source /root/gentooinstall/config.gentooinstall
 
-##Wiping: Securely erase target
+## Wiping: Securely erase target
 echo -e "\nWiping target drive entirely!"
 if [ $machineused == "vm" ] || [ $machineused == "VM" ]; then
     blkdiscard -z -f /dev/$drive ; sync

--- a/gentooinstall.sh
+++ b/gentooinstall.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 ## Copyright (C) 2022 bunnicash "@bunnicash" and licensed under GPL-2.0
-version="v0.1-006 alpha"
+version="v0.1-007"
 
-##Colors
+## Colors
 c-mg () {
-    echo -ne "\e[35m" # Magenta
+    echo -ne "\e[95m" # Magenta
 }
 c-df () {
     echo -ne "\e[39m" # Default
 }
 
-##Gentooinstall
+## Gentooinstall (Start)
 cd /root/gentooinstall && chmod +x *.sh
 c-mg && echo -ne "
 
@@ -26,7 +26,7 @@ c-mg && echo -ne "
 
 " && c-df
 
-# Configuration
+## Configuration
 read -p "Edit gentooinstall configuration [1] or use defaults [2]? " gentooconfig
 if [ $gentooconfig == "1" ]; then
     echo -e "Starting editor (CTRL+O to save, CTRL+X to quit) \n" && sleep 2
@@ -35,15 +35,16 @@ elif [ $gentooconfig == "2" ]; then
     echo -e "Using default configuration... \n"
 fi
 
-# Modules
+## Modules
 bash discard.sh
 bash startup.sh
 cd /root && mv gentooinstall /mnt/gentoo/root
 chroot /mnt/gentoo /root/gentooinstall/main.sh
+
+## Gentooinstall (Exit)
 echo " " && rm -rf /mnt/gentoo/root/gentooinstall
 umount -l /mnt/gentoo/dev{/shm,/pts,}
 umount -R /mnt/gentoo 
-
 c-mg && echo -ne "
 
      /#####\.                |
@@ -57,15 +58,4 @@ c-mg && echo -ne "
      /#####/'                |
 
 " && c-df
-sleep 3 && reboot 
-
-
-
-
-
-
-
-
-
-
-
+sleep 2 && reboot

--- a/main.sh
+++ b/main.sh
@@ -2,13 +2,14 @@
 ## Copyright (C) 2022 bunnicash "@bunnicash" and licensed under GPL-2.0
 source /root/gentooinstall/config.gentooinstall
 
-## Finishing Chroot
+## Finalize Chroot
 source /etc/profile
+export PS1="gentoo-chroot ${PS1}"
 mount /dev/${drive}1 /boot
 emerge-webrsync
 
 ## Building Profile
-eselect profile $gprof  # eselect profile list
+eselect profile $gprof
 emerge --verbose --update --deep --newuse @world
 
 ## Machine Timezone, Locale 
@@ -60,9 +61,7 @@ rc-update add net.$netdev default
 echo " "
 
 ## Bootloader: GRUB
-echo -ne "
-GRUB_PLATFORMS=\"efi-64\"
-" >> /etc/portage/make.conf 
+echo -e "GRUB_PLATFORMS=\"efi-64\" " >> /etc/portage/make.conf 
 emerge sys-boot/grub
 grub-install --target=x86_64-efi --efi-directory=/boot 
 grub-mkconfig -o /boot/grub/grub.cfg 

--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,7 @@
 ## Copyright (C) 2022 bunnicash "@bunnicash" and licensed under GPL-2.0
 source /root/gentooinstall/config.gentooinstall
 
-##Partitioning
+## Partitioning
 umount -A --recursive /mnt
 partprobe /dev/$drive
 sgdisk -Z /dev/$drive
@@ -21,21 +21,19 @@ mkfs.ext4 /dev/${drive}3
 echo " " && lsblk && sleep 2
 mkdir /mnt/gentoo && mount /dev/${drive}3 /mnt/gentoo
 
-##Timezone
+## Import Gentoo Stages
 ntpd -q -g
 date
-
-## Import Gentoo Stages
 cd /mnt/gentoo
-wget $stagelink
-# TODO Use "links" instead? TUI browser (https://wiki.gentoo.org/wiki/Handbook:AMD64/Installation/Stage - "links http://distfiles.gentoo.org/releases/amd64/autobuilds/")
+links $getstage
+clear 
 tar xpvf stage3-*.tar.xz --xattrs-include='*.*' --numeric-owner
-clear && ls
 
 ## Configure make.conf (/mnt/gentoo/etc/portage)
 cd etc/portage
 # common_flags, makeopts
 sed -i 's/^COMMON_FLAGS="-02 -pipe"/COMMON_FLAGS="-march=native -02 -pipe"/' make.conf
+jthreads=$(nproc --all)
 if [ $jthreads -le $jsplit ]; then
     echo -ne "
     MAKEOPTS=\"-j$jthreads\"
@@ -57,7 +55,6 @@ USE=\"$use_flg\"
 " >> make.conf
 
 # gentoo_mirrors (https://wiki.gentoo.org/wiki/GENTOO_MIRRORS, https://www.gentoo.org/downloads/mirrors/
-echo "Starting Mirrorselect: Please choose your desired mirrors!" && sleep 2
 mirrorselect -i -o >> /mnt/gentoo/etc/portage/make.conf
 clear
 mkdir --parents /mnt/gentoo/etc/portage/repos.conf


### PR DESCRIPTION
- Use TUI browser "links" to access the latest stage files, avoids having to update a static stage link at the cost of a few non-automated clicks
- Code refactoring, updated readme and config
- Further improved thread based make.conf setup introduced in https://github.com/bunnicash/gentooinstall/commit/35825975a031f547d83bbc8f1bcd3a5091d97cc8 
- Drop the "alpha" naming from now on